### PR TITLE
fix: prevent non-NFT avatars being rendered as NFT Cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- A regular Avatar could be rendered as an NFT Card, resulting in an error
+  ([#5](https://github.com/h4l/headgear/issues/5))
 
 ## [0.1.0] - 2022-10-16
 

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -245,6 +245,52 @@ describe("_createAvatarSvgStateSignal()", () => {
     }
   );
 
+  test.each`
+    unimplementedStyle
+    ${ImageStyleType.HEADSHOT_CIRCLE}
+    ${ImageStyleType.HEADSHOT_HEX}
+  `(
+    "defaults to available image style if requested image style is not implemented",
+    ({ unimplementedStyle }: { unimplementedStyle: ImageStyleType }) => {
+      jest
+        .mocked(createStandardAvatarSVG)
+        .mockReturnValue(document.createElementNS(SVGNS, "svg"));
+      const avatarDataState: Partial<AvatarDataState> = {
+        type: DataStateType.LOADED,
+      };
+      const controlsState = signal<ControlsState>(undefined);
+      const svgStateSignal = _createAvatarSvgState({
+        avatarDataState: signal(avatarDataState as AvatarDataState),
+        controlsState,
+      });
+      controlsState.value = { imageStyle: unimplementedStyle };
+      expect(svgStateSignal.value).toBe(
+        '<svg xmlns="http://www.w3.org/2000/svg"/>'
+      );
+      expect(createStandardAvatarSVG).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  test("defaults to available image style if NFT style is requested with non-NFT calendar", () => {
+    jest
+      .mocked(createStandardAvatarSVG)
+      .mockReturnValue(document.createElementNS(SVGNS, "svg"));
+    const avatarDataState: Partial<AvatarDataState> = {
+      type: DataStateType.LOADED,
+      avatar: { nftInfo: undefined, accessories: [], styles: [] },
+    };
+    const controlsState = signal<ControlsState>(undefined);
+    const svgStateSignal = _createAvatarSvgState({
+      avatarDataState: signal(avatarDataState as AvatarDataState),
+      controlsState,
+    });
+    controlsState.value = { imageStyle: ImageStyleType.NFT_CARD };
+    expect(svgStateSignal.value).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"/>'
+    );
+    expect(createStandardAvatarSVG).toHaveBeenCalledTimes(1);
+  });
+
   test("handles failure to compose avatar accessories into single SVG", () => {
     const err = new Error("failed to generate SVG");
     jest.mocked(composeAvatarSVG).mockImplementation(() => {


### PR DESCRIPTION
Non-NFT avatars were being rendered with the NFT Card style if the NFT Card style option was restored from storage and the current Avatar was not an NFT Avatar. The style now defaults to the Standard style if an incompatible or unimplemented style is requested.

This fixes https://github.com/h4l/headgear/issues/5