### PR TITLE
fix: use correct viewBox height in Headshot Circle

### DIFF
--- a/src/__tests__/__snapshots__/svg.ts.snap
+++ b/src/__tests__/__snapshots__/svg.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Avatar SVG Headshot Circle Layout - createHeadshotCircleAvatarSVG() renders avatar in styled container 1`] = `
 <svg
-  viewBox="0 63.5 380 544"
+  viewBox="0 63.5 380 480.5"
   xmlns="http://www.w3.org/2000/svg"
 >
   <defs>

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -552,6 +552,7 @@ export function createNFTCardAvatarSVG({
 }
 
 const HEADSHOT_CIRCLE_RADIUS = 153.5;
+const HEADSHOT_CIRCLE_BASE_HEIGHT = 544;
 
 export function createHeadshotCircleAvatarSVG({
   composedAvatar,
@@ -582,7 +583,10 @@ export function createHeadshotCircleAvatarSVG({
   window.document.body.append(svg);
   const avatarArea = avatar.getBBox();
   const padding = ACC_W / 2 - HEADSHOT_CIRCLE_RADIUS;
-  viewBox[1] = `${Math.max(0, avatarArea.y - padding)}`;
+  const top = Math.max(0, avatarArea.y - padding);
+  const height = HEADSHOT_CIRCLE_BASE_HEIGHT - top;
+  viewBox[1] = `${top}`;
+  viewBox[3] = `${height}`;
   svg.setAttribute("viewBox", viewBox.join(" "));
   svg.remove();
   svg.removeAttribute("style");


### PR DESCRIPTION
The Headshot Circle layout had extra padding at the bottom. We were treating the 4th viewBox param as a y coord, but it's the height of the rect.

This fixes https://github.com/h4l/headgear/issues/10