### PR TITLE
feat: download or copy Avatar as a PNG image

### DIFF
--- a/src/__tests__/__snapshots__/svg.ts.snap
+++ b/src/__tests__/__snapshots__/svg.ts.snap
@@ -839,9 +839,7 @@ exports[`Avatar SVG NFT Card Layout - createNFTCardAvatarSVG() renders regular N
 
 exports[`Avatar SVG Standard Layout - createStandardAvatarSVG() renders avatar in styled container 1`] = `
 <svg
-  height="100%"
   viewBox="0 0 587 718"
-  width="100%"
   xmlns="http://www.w3.org/2000/svg"
 >
   <rect

--- a/src/__tests__/background.ts
+++ b/src/__tests__/background.ts
@@ -8,6 +8,7 @@ import {
 import { _persistImageControlsOnChange } from "../background";
 import {
   ControlsStateObject,
+  DEFAULT_CONTROLS_STATE,
   ImageStyleType,
   PORT_IMAGE_CONTROLS_CHANGED,
   STORAGE_KEY_IMAGE_CONTROLS,
@@ -26,9 +27,11 @@ describe("_persistImageControlsOnChange()", () => {
     const syncStorage = chrome.storage.sync as MockSyncStorageArea;
     const port = new MockPort(PORT_IMAGE_CONTROLS_CHANGED);
     const controlsState1: ControlsStateObject = {
+      ...DEFAULT_CONTROLS_STATE,
       imageStyle: ImageStyleType.NFT_CARD,
     };
     const controlsState2: ControlsStateObject = {
+      ...DEFAULT_CONTROLS_STATE,
       imageStyle: ImageStyleType.HEADSHOT_HEX,
     };
 
@@ -57,6 +60,7 @@ describe("_persistImageControlsOnChange()", () => {
     const syncStorage = chrome.storage.sync as MockSyncStorageArea;
     const port = new MockPort(PORT_IMAGE_CONTROLS_CHANGED);
     const controlsState: ControlsStateObject = {
+      ...DEFAULT_CONTROLS_STATE,
       imageStyle: ImageStyleType.NFT_CARD,
     };
 

--- a/src/__tests__/popup-state-persistence.ts
+++ b/src/__tests__/popup-state-persistence.ts
@@ -1,0 +1,17 @@
+import {
+  ControlsStateObject,
+  DEFAULT_CONTROLS_STATE,
+  isControlsStateObject,
+} from "../popup-state-persistence";
+
+test("isControlsStateObject", () => {
+  expect(isControlsStateObject(DEFAULT_CONTROLS_STATE)).toBeTruthy();
+  Object.keys(DEFAULT_CONTROLS_STATE).forEach((k) => {
+    const obj: Partial<ControlsStateObject> = { ...DEFAULT_CONTROLS_STATE };
+    delete obj[k as keyof ControlsStateObject];
+    expect(isControlsStateObject(obj)).toBeFalsy();
+
+    obj[k as keyof ControlsStateObject] = undefined;
+    expect(isControlsStateObject(obj)).toBeFalsy();
+  });
+});

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -569,21 +569,23 @@ describe("<ErrorBoundary>", () => {
 
 describe("<DownloadImageButton>", () => {
   test.each`
-    format                   | extension
-    ${OutputImageFormat.PNG} | ${"png"}
-    ${OutputImageFormat.SVG} | ${"svg"}
+    format                   | extension | label
+    ${OutputImageFormat.PNG} | ${"png"}  | ${"Download Image"}
+    ${OutputImageFormat.SVG} | ${"svg"}  | ${"Download SVG Image"}
   `(
     "is disabled until state is available",
-    async (options: { format: OutputImageFormat; extension: string }) => {
+    async (options: {
+      format: OutputImageFormat;
+      extension: string;
+      label: string;
+    }) => {
       const {
         renderWithStateContext,
         state: { controlsState, outputImageState },
       } = statefulElementRenderer(<DownloadImageButton />);
       renderWithStateContext();
 
-      let button = await screen.findByRole("button", {
-        name: `Download Image`,
-      });
+      let button = await screen.findByRole("button");
       expect(button).toHaveAttribute("aria-disabled");
       expect(button).toHaveAttribute("href", "#");
       expect(button).not.toHaveAttribute("download");
@@ -604,7 +606,7 @@ describe("<DownloadImageButton>", () => {
         expect(button).not.toHaveAttribute("aria-disabled");
       });
       button = await screen.findByRole("button", {
-        name: `Download Image`,
+        name: options.label,
       });
       expect(button).toHaveAttribute(
         "download",
@@ -902,6 +904,33 @@ describe("<Controls>", () => {
     expect(controlsState.value.imageOptionsUIOpen).toBeTruthy();
     fireEvent.click(settingsBtn);
     expect(controlsState.value.imageOptionsUIOpen).toBeFalsy();
+  });
+
+  test("Copy button is not shown for SVG image output", async () => {
+    const {
+      state: { controlsState },
+      renderWithStateContext,
+    } = statefulElementRenderer(<Controls />);
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      outputImageFormat: OutputImageFormat.PNG,
+    };
+    renderWithStateContext();
+
+    expect(
+      await screen.queryByRole("button", { name: "Copy Image" })
+    ).not.toBeNull();
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      outputImageFormat: OutputImageFormat.SVG,
+    };
+    await waitFor(async () => {
+      expect(
+        await screen.queryByRole("button", { name: "Copy Image" })
+      ).toBeNull();
+    });
   });
 });
 

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -33,6 +33,7 @@ import {
   ImageOptions,
   ImageStyleOption,
   OutputImageContext,
+  OutputImageScaleRadio,
   OutputImageState,
   RootState,
   _createAvatarSvgState,
@@ -901,6 +902,31 @@ describe("<Controls>", () => {
     expect(controlsState.value.imageOptionsUIOpen).toBeTruthy();
     fireEvent.click(settingsBtn);
     expect(controlsState.value.imageOptionsUIOpen).toBeFalsy();
+  });
+});
+
+describe("<OutputImageScaleRadio>", () => {
+  // eslint-disable-next-line jest/expect-expect
+  test("displays scaled image size", async () => {
+    const {
+      state: { avatarSvgState },
+      renderWithStateContext,
+    } = statefulElementRenderer(
+      <OutputImageScaleRadio
+        scale={3}
+        label="Huge"
+        value={RasterImageSize.XLARGE}
+      />
+    );
+    renderWithStateContext();
+    await screen.getByLabelText("? \u00d7 ? pixels", { exact: false });
+
+    avatarSvgState.value = parseSVG(
+      `<svg xmlns="${SVGNS}" viewBox="0 0 10 20"/>`
+    );
+    await waitFor(async () => {
+      await screen.getByLabelText("30 \u00d7 60 pixels", { exact: false });
+    });
   });
 });
 

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/preact";
 import { ComponentChildren } from "preact";
 import { Fragment, JSX } from "preact/jsx-runtime";
@@ -28,6 +29,7 @@ import {
   DisplayArea,
   DownloadSVGButton,
   ErrorBoundary,
+  ImageOptions,
   ImageStyleOption,
   RootState,
   _createAvatarSvgState,
@@ -35,8 +37,11 @@ import {
   createRootState,
 } from "../popup";
 import {
+  DEFAULT_CONTROLS_STATE,
   ImageStyleType,
+  OutputImageFormat,
   PORT_IMAGE_CONTROLS_CHANGED,
+  RasterImageSize,
   STORAGE_KEY_IMAGE_CONTROLS,
 } from "../popup-state-persistence";
 import { MSG_GET_AVATAR } from "../reddit-interaction";
@@ -74,8 +79,14 @@ describe("create & initialise RootState", () => {
   });
 
   test("controlsState changes trigger messages on image-controls-changed channel", () => {
-    const state1 = { imageStyle: ImageStyleType.NFT_CARD };
-    const state2 = { imageStyle: ImageStyleType.HEADSHOT_HEX };
+    const state1 = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.NFT_CARD,
+    };
+    const state2 = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.HEADSHOT_HEX,
+    };
     let port: chrome.runtime.Port | undefined;
     chrome.runtime.onConnect.addListener((_port) => {
       port = _port;
@@ -109,6 +120,7 @@ describe("create & initialise RootState", () => {
 
     await waitFor(() => {
       expect(rootState.controlsState.value).toEqual({
+        ...DEFAULT_CONTROLS_STATE,
         imageStyle: ImageStyleType.NFT_CARD,
       });
     });
@@ -130,6 +142,7 @@ describe("create & initialise RootState", () => {
 
       await waitFor(() => {
         expect(rootState.controlsState.value).toEqual({
+          ...DEFAULT_CONTROLS_STATE,
           imageStyle: ImageStyleType.STANDARD,
         });
       });
@@ -238,7 +251,7 @@ describe("_createAvatarSvgStateSignal()", () => {
       const controlsState: ControlsState =
         imageStyleType === undefined
           ? undefined
-          : { imageStyle: imageStyleType };
+          : { ...DEFAULT_CONTROLS_STATE, imageStyle: imageStyleType };
       const svgStateSignal = _createAvatarSvgState({
         avatarDataState: signal(avatarDataState as AvatarDataState),
         controlsState: signal(controlsState),
@@ -260,7 +273,10 @@ describe("_createAvatarSvgStateSignal()", () => {
       avatarDataState: signal(avatarDataState as AvatarDataState),
       controlsState,
     });
-    controlsState.value = { imageStyle: ImageStyleType.NFT_CARD };
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.NFT_CARD,
+    };
     expect(svgStateSignal.value).toBe(
       '<svg xmlns="http://www.w3.org/2000/svg"/>'
     );
@@ -278,7 +294,10 @@ describe("_createAvatarSvgStateSignal()", () => {
         type: DataStateType.LOADED,
         avatar: {},
       } as unknown as AvatarDataState),
-      controlsState: signal({ imageStyle: ImageStyleType.NO_BG }),
+      controlsState: signal({
+        ...DEFAULT_CONTROLS_STATE,
+        imageStyle: ImageStyleType.NO_BG,
+      }),
     });
 
     expect(svgSignal.value).toEqual(err);
@@ -311,7 +330,7 @@ describe("_createAvatarSvgStateSignal()", () => {
           type: DataStateType.LOADED,
           avatar: { nftInfo: {} },
         } as unknown as AvatarDataState),
-        controlsState: signal({ imageStyle }),
+        controlsState: signal({ ...DEFAULT_CONTROLS_STATE, imageStyle }),
       });
 
       expect(svgSignal.value).toEqual(err);
@@ -346,7 +365,7 @@ describe("_createAvatarSvgStateSignal()", () => {
           type: DataStateType.LOADED,
           avatar: { nftInfo: {} },
         } as unknown as AvatarDataState),
-        controlsState: signal({ imageStyle }),
+        controlsState: signal({ ...DEFAULT_CONTROLS_STATE, imageStyle }),
       });
 
       expect(svgSignal.value).toBe(
@@ -372,6 +391,7 @@ describe("<ClosePopupButton>", () => {
 describe("<ImageStyleOption>", () => {
   test("sets imageStyle when clicked", async () => {
     const controlsState: Signal<ControlsState> = signal({
+      ...DEFAULT_CONTROLS_STATE,
       imageStyle: ImageStyleType.NFT_CARD,
     });
     render(
@@ -435,7 +455,10 @@ describe("<ImageStyleOption>", () => {
       />
     );
 
-    controlsState.value = { imageStyle: ImageStyleType.HEADSHOT_CIRCLE };
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.HEADSHOT_CIRCLE,
+    };
 
     for (const stateType of [
       DataStateType.BEFORE_LOAD,
@@ -525,7 +548,10 @@ describe("<DownloadSVGButton>", () => {
     expect(button).toHaveAttribute("href", "#");
     expect(button).not.toHaveAttribute("download");
 
-    controlsState.value = { imageStyle: ImageStyleType.STANDARD };
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.STANDARD,
+    };
     avatarSvgState.value = "<svg/>";
 
     await waitFor(async () => {
@@ -581,7 +607,10 @@ describe("<DisplayArea>", () => {
     await screen.findByRole("progressbar");
     cleanup();
 
-    controlsState.value = { imageStyle: ImageStyleType.STANDARD };
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.STANDARD,
+    };
     renderWithStateContext();
     await screen.findByRole("progressbar");
     cleanup();
@@ -603,7 +632,10 @@ describe("<DisplayArea>", () => {
     avatarDataState.value = {
       type: DataStateType.LOADED,
     } as unknown as AvatarDataState;
-    controlsState.value = { imageStyle: ImageStyleType.STANDARD };
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.STANDARD,
+    };
     avatarSvgState.value = "<svg/>";
 
     renderWithStateContext();
@@ -641,7 +673,10 @@ describe("<Controls>", () => {
       type: DataStateType.LOADED,
       avatar: { nftInfo: {} },
     } as unknown as AvatarDataState;
-    controlsState.value = { imageStyle: ImageStyleType.STANDARD };
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageStyle: ImageStyleType.STANDARD,
+    };
     renderWithStateContext();
 
     let button = await screen.findByLabelText("NFT Card", { exact: false });
@@ -671,4 +706,193 @@ describe("<Controls>", () => {
     fireEvent.click(button);
     expect(controlsState.value.imageStyle).toBe(ImageStyleType.HEADSHOT_HEX);
   });
+
+  test("Settings button toggles the Image Options UI", async () => {
+    const {
+      state: { controlsState },
+      renderWithStateContext,
+    } = statefulElementRenderer(<Controls />);
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageOptionsUIOpen: false,
+    };
+    renderWithStateContext();
+    const settingsBtn = await screen.findByRole("button", { name: "Settings" });
+    fireEvent.click(settingsBtn);
+    expect(controlsState.value.imageOptionsUIOpen).toBeTruthy();
+    fireEvent.click(settingsBtn);
+    expect(controlsState.value.imageOptionsUIOpen).toBeFalsy();
+  });
+});
+
+describe("<ImageOptions>", () => {
+  test("dialog opens and closes with state", async () => {
+    const {
+      state: { controlsState },
+      renderWithStateContext,
+    } = statefulElementRenderer(<ImageOptions />);
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageOptionsUIOpen: false,
+    };
+    renderWithStateContext();
+    expect(
+      await screen.queryByRole("dialog", { name: "Image Output Options" })
+    ).toBeNull();
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageOptionsUIOpen: true,
+    };
+    await screen.findByRole("dialog", {
+      name: "Image Output Options",
+    });
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageOptionsUIOpen: false,
+    };
+    await waitFor(async () => {
+      expect(
+        await screen.queryByRole("dialog", { name: "Image Output Options" })
+      ).toBeNull();
+    });
+  });
+
+  test("clicking the close button closes the dialog", async () => {
+    const {
+      state: { controlsState },
+      renderWithStateContext,
+    } = statefulElementRenderer(<ImageOptions />);
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageOptionsUIOpen: true,
+    };
+    renderWithStateContext();
+    const dialog = await screen.getByRole("dialog", {
+      name: "Image Output Options",
+    });
+    const closeBtn = await within(dialog).getByRole("button", {
+      name: "Close",
+    });
+    fireEvent.click(closeBtn);
+    expect(
+      await screen.queryByRole("dialog", {
+        name: "Image Output Options",
+      })
+    ).toBeNull();
+  });
+
+  test("clicking the modal background closes the dialog", async () => {
+    const {
+      state: { controlsState },
+      renderWithStateContext,
+    } = statefulElementRenderer(<ImageOptions />);
+
+    controlsState.value = {
+      ...DEFAULT_CONTROLS_STATE,
+      imageOptionsUIOpen: true,
+    };
+    renderWithStateContext();
+    await screen.queryByRole("dialog", { name: "Image Output Options" });
+    const background = await screen.getByTestId("modal-bg");
+    fireEvent.click(background);
+    expect(
+      await screen.queryByRole("dialog", {
+        name: "Image Output Options",
+      })
+    ).toBeNull();
+  });
+
+  test.each`
+    name               | value
+    ${"Vector Images"} | ${OutputImageFormat.SVG}
+    ${"Normal Images"} | ${OutputImageFormat.PNG}
+  `(
+    "Sets $name format when clicking its radio button",
+    async (options: { name: string; value: OutputImageFormat }) => {
+      const {
+        state: { controlsState },
+        renderWithStateContext,
+      } = statefulElementRenderer(<ImageOptions />);
+
+      controlsState.value = {
+        ...DEFAULT_CONTROLS_STATE,
+        imageOptionsUIOpen: true,
+      };
+      renderWithStateContext();
+      const radio = await screen.getByLabelText(options.name);
+      fireEvent.click(radio);
+      await waitFor(() => {
+        expect(controlsState.value?.outputImageFormat).toBe(options.value);
+      });
+    }
+  );
+
+  test.each`
+    name         | value
+    ${"Small"}   | ${RasterImageSize.SMALL}
+    ${"Medium"}  | ${RasterImageSize.MEDIUM}
+    ${/^Large/}  | ${RasterImageSize.LARGE}
+    ${"X-Large"} | ${RasterImageSize.XLARGE}
+  `(
+    "Sets $name size when clicking its radio button",
+    async (options: { name: string; value: RasterImageSize }) => {
+      const {
+        state: { controlsState },
+        renderWithStateContext,
+      } = statefulElementRenderer(<ImageOptions />);
+
+      controlsState.value = {
+        ...DEFAULT_CONTROLS_STATE,
+        imageOptionsUIOpen: true,
+        rasterImageSize: RasterImageSize.EXACT_HEIGHT,
+      };
+      renderWithStateContext();
+      const radio = await screen.getByLabelText(options.name, { exact: false });
+      fireEvent.click(radio);
+      await waitFor(() => {
+        expect(controlsState.value?.rasterImageSize).toBe(options.value);
+      });
+    }
+  );
+
+  test.each`
+    name        | value
+    ${"Width"}  | ${RasterImageSize.EXACT_WIDTH}
+    ${"Height"} | ${RasterImageSize.EXACT_HEIGHT}
+  `(
+    "Sets exact $name size when clicking and filling its input",
+    async (options: { name: string; value: RasterImageSize }) => {
+      const {
+        state: { controlsState },
+        renderWithStateContext,
+      } = statefulElementRenderer(<ImageOptions />);
+
+      controlsState.value = {
+        ...DEFAULT_CONTROLS_STATE,
+        imageOptionsUIOpen: true,
+      };
+      renderWithStateContext();
+      const input = await screen.getByLabelText(options.name, { exact: false });
+      assert(input instanceof HTMLInputElement);
+      fireEvent.click(input);
+      await waitFor(() => {
+        expect(controlsState.value?.rasterImageSize).toBe(options.value);
+      });
+
+      input.value = "1234";
+      fireEvent.blur(input);
+      await waitFor(() => {
+        expect(
+          options.value === RasterImageSize.EXACT_WIDTH
+            ? controlsState.value?.rasterImageExactWidth
+            : controlsState.value?.rasterImageExactHeight
+        ).toBe(1234);
+      });
+    }
+  );
 });

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -823,6 +823,21 @@ describe("<DisplayArea>", () => {
     await screen.findByTestId("error");
     await cleanup();
   });
+
+  test("displays error when in failed OutputImageState", async () => {
+    const {
+      state: { outputImageState },
+      renderWithStateContext,
+    } = statefulElementRenderer(<DisplayArea />);
+
+    outputImageState.value = new Error("oops");
+    renderWithStateContext();
+    const errorContainer = await screen.findByTestId("error");
+    expect(errorContainer).toHaveTextContent(
+      "Headgear hit an error while generating the image to be downloaded/copied."
+    );
+    await cleanup();
+  });
 });
 
 describe("<Controls>", () => {

--- a/src/__tests__/svg-rasterisation.ts
+++ b/src/__tests__/svg-rasterisation.ts
@@ -1,0 +1,7 @@
+import { rasteriseSVG } from "../svg-rasterisation";
+
+test("rasteriseSVG() exists", () => {
+  // I don't think it's really practical to test rasteriseSVG() in a jsdom
+  // environment.
+  expect(typeof rasteriseSVG).toBe("function");
+});

--- a/src/popup-state-persistence.ts
+++ b/src/popup-state-persistence.ts
@@ -9,19 +9,57 @@ export enum ImageStyleType {
   HEADSHOT_CIRCLE = "headshot-circle",
 }
 
+export enum OutputImageFormat {
+  SVG = "svg",
+  PNG = "png",
+}
+
+export enum RasterImageSize {
+  SMALL = "sm",
+  MEDIUM = "md",
+  LARGE = "lg",
+  XLARGE = "xl",
+  EXACT_WIDTH = "height",
+  EXACT_HEIGHT = "width",
+}
+
 /** The state of the image controls panel. */
 export interface ControlsStateObject {
   imageStyle: ImageStyleType;
+  scrollPosition: number;
+  imageOptionsUIOpen: boolean;
+  outputImageFormat: OutputImageFormat;
+  rasterImageExactWidth: number;
+  rasterImageExactHeight: number;
+  rasterImageSize: RasterImageSize;
 }
 
+export const DEFAULT_CONTROLS_STATE: ControlsStateObject = Object.freeze({
+  imageStyle: ImageStyleType.STANDARD,
+  scrollPosition: 0,
+  imageOptionsUIOpen: false,
+  outputImageFormat: OutputImageFormat.PNG,
+  rasterImageExactWidth: 1000,
+  rasterImageExactHeight: 1000,
+  rasterImageSize: RasterImageSize.MEDIUM,
+});
+
 const _imageStyleTypeValues = Object.freeze(Object.values(ImageStyleType));
+const _imageFormats = Object.freeze(Object.values(OutputImageFormat));
+const _imageSizes = Object.freeze(Object.values(RasterImageSize));
+
 export function isControlsStateObject(
   obj: unknown
 ): obj is ControlsStateObject {
+  const _obj = obj as Partial<ControlsStateObject>;
   return (
-    typeof obj === "object" &&
-    _imageStyleTypeValues.includes(
-      (obj as Partial<ControlsStateObject>).imageStyle as ImageStyleType
-    )
+    typeof _obj === "object" &&
+    _imageStyleTypeValues.includes(_obj.imageStyle as ImageStyleType) &&
+    typeof _obj.scrollPosition === "number" &&
+    typeof _obj.imageOptionsUIOpen === "boolean" &&
+    _imageFormats.includes(_obj.outputImageFormat as OutputImageFormat) &&
+    typeof _obj.rasterImageExactWidth === "number" &&
+    typeof _obj.rasterImageExactHeight === "number" &&
+    _imageSizes.includes(_obj.rasterImageSize as RasterImageSize)
   );
 }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -77,7 +77,7 @@ export type AvatarDataState =
  * data, depending on the UI controls state. `undefined` while data or UI
  * controls are loading, or if an error occurs.
  */
-export type AvatarSVGState = Error | string | undefined;
+export type AvatarSVGState = Error | SVGElement | undefined;
 
 // undefined while loading from storage
 export type ControlsState = undefined | ControlsStateObject;
@@ -356,13 +356,13 @@ function RequestBugReport() {
   );
 }
 
-export function AvatarSVG({ svg }: { svg: string }) {
+export function AvatarSVG({ svg }: { svg: SVGElement }) {
   return (
     <svg
       data-testid="avatar"
       class="object-contain w-full h-full drop-shadow-xl animate-fade-in"
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: svg }}
+      dangerouslySetInnerHTML={{ __html: svg.outerHTML }}
     />
   );
 }
@@ -620,8 +620,8 @@ export function DownloadSVGButton(): JSX.Element {
   const avatarSvgState = useContext(AvatarSvgContext).value;
 
   const downloadUri = useMemo(() => {
-    if (typeof avatarSvgState !== "string") return "#";
-    const b64Svg = btoa(avatarSvgState);
+    if (!(avatarSvgState instanceof SVGElement)) return "#";
+    const b64Svg = btoa(new XMLSerializer().serializeToString(avatarSvgState));
     return `data:image/svg+xml;base64,${b64Svg}`;
   }, [avatarSvgState]);
 
@@ -631,7 +631,8 @@ export function DownloadSVGButton(): JSX.Element {
     assert(imgStyleName);
     filename = `Reddit Avatar ${imgStyleName}.svg`;
   }
-  const disabled = typeof avatarSvgState !== "string" || filename === undefined;
+  const disabled =
+    !(avatarSvgState instanceof SVGElement) || filename === undefined;
 
   return (
     <a
@@ -1358,7 +1359,7 @@ export function _createAvatarSvgState({
       imageStyle: ImageStyleType,
       avatar: ResolvedAvatar,
       composedAvatar: SVGElement
-    ): string => {
+    ): SVGElement => {
       let svg: SVGElement;
       if (imageStyle === ImageStyleType.NFT_CARD) {
         if (!avatar.nftInfo)
@@ -1380,7 +1381,7 @@ export function _createAvatarSvgState({
         svg = createStandardAvatarSVG({ composedAvatar });
       }
 
-      return new XMLSerializer().serializeToString(svg);
+      return svg;
     }
   );
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1129,7 +1129,13 @@ export function OutputImageScaleRadio(props: {
   scale: number;
 }): JSX.Element {
   const controlsState = useContext(ControlsContext);
-  const [w, h] = [380 * props.scale, 600 * props.scale];
+  const avatarSvgState = useContext(AvatarSvgContext);
+
+  let scaledSize: { width?: number; height?: number } = {};
+  if (avatarSvgState.value && !(avatarSvgState.value instanceof Error)) {
+    const { width, height } = _getBaseSize(avatarSvgState.value);
+    scaledSize = { width: width * props.scale, height: height * props.scale };
+  }
   return (
     <div class="flex my-1">
       <div class="flex items-center h-5">
@@ -1156,9 +1162,10 @@ export function OutputImageScaleRadio(props: {
           for={`output-image-scale-${props.value}`}
           class="font-medium text-gray-900 dark:text-gray-300"
         >
-          {props.label}{" "}
+          <span class="w-16 inline-block">{props.label} </span>
           <span class="font-normal text-xs">
-            ≈ {w} {"\u00d7"} {h} pixels
+            {scaledSize.width || "?"} {"\u00d7"} {scaledSize.height || "?"}{" "}
+            pixels
           </span>
         </label>
       </div>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -645,7 +645,13 @@ export function BottomButtons() {
   return (
     <div class="flex">
       <DownloadImageButton />
-      <CopyImageButton />
+      {/* Chrome does not allow SVG (image/svg+xml) to be copied to the
+          clipboard. We could copy it as text/plain, but that would be
+          inconsistent with the expectation of copying an image, so I think it's
+          best to just now allow copying SVG. */}
+      {!(controlsState.value?.outputImageFormat === OutputImageFormat.SVG) && (
+        <CopyImageButton />
+      )}
       <button
         aria-label="Settings"
         onClick={toggleImageOptionsUI}
@@ -728,7 +734,10 @@ export function DownloadImageButton(): JSX.Element {
           class="text-inherit m-1 drop-shadow-lg shadow-slate-900"
           style="text-shadow: 0px 0px 3px rgb(0 0 0 / 0.3)"
         >
-          Download Image
+          {controlsState &&
+          controlsState.outputImageFormat === OutputImageFormat.SVG
+            ? "Download SVG Image"
+            : "Download Image"}
         </span>
       </span>
     </a>
@@ -768,7 +777,12 @@ export function CopyImageButton(): JSX.Element {
       .then(() => {
         copyState.value = CopyState.COPIED;
       })
-      .catch(() => {
+      .catch((e) => {
+        console.error(
+          "Failed to copy image data to clipboard:",
+          Object.getPrototypeOf(e),
+          e.message
+        );
         copyState.value = CopyState.FAILED;
       });
   };

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -415,6 +415,7 @@ export function DisplayArea() {
   const avatarDataState = useContext(AvatarDataContext);
   const controlsState = useContext(ControlsContext);
   const avatarSvgState = useContext(AvatarSvgContext);
+  const outputImageState = useContext(OutputImageContext);
 
   let content: JSX.Element;
   if (avatarDataState.value.type === DataStateType.ERROR) {
@@ -429,6 +430,20 @@ export function DisplayArea() {
         <p>
           Headgear could not load your Avatar because it was not able to
           generate an SVG image from Reddit's Avatar data.
+        </p>
+        <RequestBugReport />
+      </CouldNotLoadAvatarMessage>
+    );
+  } else if (outputImageState.value instanceof Error) {
+    content = (
+      <CouldNotLoadAvatarMessage
+        title="Something went wrong"
+        logErrorContextMessage="Failed to generate output image: "
+        logError={outputImageState.value}
+      >
+        <p>
+          Headgear hit an error while generating the image to be
+          downloaded/copied.
         </p>
         <RequestBugReport />
       </CouldNotLoadAvatarMessage>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -144,21 +144,53 @@ const iconCross = (
 );
 
 /**
- * cog-6-tooth Solid
+ * cog-6-tooth Outline
  * https://heroicons.com/
  */
 function IconCog6(props: { class?: string }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      fill="none"
       viewBox="0 0 24 24"
-      fill="currentColor"
+      strokeWidth={1.5}
+      stroke="currentColor"
       class={props.class || "w-6 h-6"}
+      style="filter: drop-shadow(0px 0px 3px rgb(0 0 0 / 0.5));"
     >
       <path
-        fill-rule="evenodd"
-        d="M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.923-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z"
-        clip-rule="evenodd"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * document-duplicate Outline
+ * https://heroicons.com/
+ */
+function IconCopy(props: { class?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      class={props.class || "w-6 h-6"}
+      style="filter: drop-shadow(0px 0px 3px rgb(0 0 0 / 0.5));"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 01-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 011.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 00-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 01-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5a3.375 3.375 0 00-3.375-3.375H9.75"
       />
     </svg>
   );
@@ -598,6 +630,7 @@ export function BottomButtons() {
   return (
     <div class="flex">
       <DownloadImageButton />
+      <CopyImageButton />
       <button
         aria-label="Settings"
         onClick={toggleImageOptionsUI}
@@ -613,10 +646,26 @@ export function BottomButtons() {
       text-slate-50 p-3
     `}
       >
-        <IconCog6 class="w-7 h-7 inline m-1" />
+        <IconCog6
+          class={`
+          hover:scale-105 transition-transform ease-out
+          w-7 h-7 inline m-1`}
+        />
       </button>
     </div>
   );
+}
+
+function bottomBarButtonStyle(disabled: boolean): string {
+  return `\
+  border-r border-r-indigo-900
+  ${
+    disabled
+      ? "cursor-not-allowed"
+      : "hover:ring active:ring hover:ring-inset active:ring-inset hover:bg-gradient-radial hover:from-indigo-500 hover:to-indigo-600"
+  }
+  bg-indigo-600 hover:text-white hover:ring-indigo-500 active:ring-indigo-400
+  flex text-lg text-slate-50 p-3`;
 }
 
 const IMAGE_STYLE_NAMES: Map<ImageStyleType, string> = new Map([
@@ -648,18 +697,7 @@ export function DownloadImageButton(): JSX.Element {
     <a
       role="button"
       aria-disabled={disabled || undefined}
-      class={`\
-      flex-grow
-      border-r border-r-indigo-900
-    ${
-      disabled
-        ? "cursor-not-allowed"
-        : "hover:ring active:ring hover:ring-inset active:ring-inset hover:bg-gradient-radial hover:from-indigo-500 hover:to-indigo-600"
-    }
-    bg-indigo-600 hover:text-white hover:ring-indigo-500 active:ring-indigo-400
-    flex text-lg font-medium
-    text-slate-50 p-3
-    `}
+      class={`flex-grow ${bottomBarButtonStyle(disabled)}`}
       onClick={disabled ? () => false : undefined}
       href={downloadUri}
       download={disabled ? undefined : filename}
@@ -667,7 +705,7 @@ export function DownloadImageButton(): JSX.Element {
       <span
         class={`\
       ${disabled ? "" : "hover:scale-105"}
-      m-auto hover:motion-reduce:scale-100  transition-transform ease-in
+      m-auto hover:motion-reduce:scale-100  transition-transform ease-out
       `}
       >
         {iconArrowDown}{" "}
@@ -675,10 +713,103 @@ export function DownloadImageButton(): JSX.Element {
           class="text-inherit m-1 drop-shadow-lg shadow-slate-900"
           style="text-shadow: 0px 0px 3px rgb(0 0 0 / 0.3)"
         >
-          Download {controlsState?.outputImageFormat.toUpperCase()} Image
+          Download Image
         </span>
       </span>
     </a>
+  );
+}
+
+enum CopyState {
+  BEFORE_COPY,
+  COPYING,
+  COPIED,
+  FAILED,
+}
+
+export function CopyImageButton(): JSX.Element {
+  const outputImageState = useContext(OutputImageContext);
+  const hovering = useSignal(false);
+  const copyState = useSignal(CopyState.BEFORE_COPY);
+  const hidden = useSignal(false);
+
+  const isImageReady = !(
+    outputImageState.value === undefined ||
+    outputImageState.value instanceof Error
+  );
+  const disabled = !isImageReady;
+
+  const copyImage = () => {
+    if (
+      outputImageState.value === undefined ||
+      outputImageState.value instanceof Error
+    ) {
+      return;
+    }
+    copyState.value = CopyState.COPYING;
+    const imageBlob = outputImageState.value.blob;
+    navigator.clipboard
+      .write([new ClipboardItem({ [imageBlob.type]: imageBlob })])
+      .then(() => {
+        copyState.value = CopyState.COPIED;
+      })
+      .catch(() => {
+        copyState.value = CopyState.FAILED;
+      });
+  };
+  const labels = {
+    [CopyState.BEFORE_COPY]: "Copy Image",
+    [CopyState.COPYING]: "Copy Image",
+    [CopyState.COPIED]: "Image Copied!",
+    [CopyState.FAILED]: "Copy Failed",
+  };
+
+  return (
+    <span class="relative flex-shrink">
+      <div
+        aria-role="tooltip"
+        class={`-top-10 -left-[2.7rem] flex absolute w-36
+        ${hovering.value ? "opacity-100" : "opacity-0"}
+        ${hidden.value ? "hidden" : ""}
+        transition-opacity duration-300`}
+      >
+        <div
+          role="tooltip"
+          class={`flex-shrink mx-auto
+         z-10 py-2 px-3
+        text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm
+        dark:bg-gray-700`}
+        >
+          {labels[copyState.value]}
+        </div>
+      </div>
+
+      <button
+        aria-label="Copy Image"
+        disabled={disabled || undefined}
+        onClick={disabled ? () => false : copyImage}
+        onTransitionEnd={() => {
+          if (!hovering.value) hidden.value = true;
+        }}
+        onMouseEnter={() => {
+          copyState.value = CopyState.BEFORE_COPY;
+          hovering.value = true;
+          hidden.value = false;
+        }}
+        onMouseLeave={() => {
+          hovering.value = false;
+        }}
+        class={bottomBarButtonStyle(disabled)}
+      >
+        <span
+          class={`
+        ${disabled ? "" : "hover:scale-105"}
+        m-auto hover:motion-reduce:scale-100  transition-transform ease-out`}
+        >
+          <IconCopy class="w-7 h-7 inline m-1" />
+        </span>
+      </button>
+    </span>
   );
 }
 

--- a/src/svg-rasterisation.ts
+++ b/src/svg-rasterisation.ts
@@ -1,0 +1,59 @@
+import { assert } from "./assert";
+
+/**
+ * Draw the SVG image on a canvas, returning a Blob containing a PNG image.
+ *
+ * The width and height is the size of the resulting image. The SVG element
+ * should be styled to fill the width x height area, e.g. via a viewBox with the
+ * same aspect ratio, or explicit width and height set to the same values.
+ */
+export async function rasteriseSVG({
+  svg,
+  width,
+  height,
+}: {
+  svg: SVGElement;
+  width: number;
+  height: number;
+}): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const renderContext = canvas.getContext("2d", {
+    alpha: true,
+    desynchronized: true,
+    willReadFrequently: false,
+  });
+  assert(renderContext);
+  // The default is low, but there doesn't appear to by any difference in
+  // practice.
+  renderContext.imageSmoothingEnabled = true;
+  renderContext.imageSmoothingQuality = "high";
+  renderContext.clearRect(0, 0, canvas.width, canvas.height);
+
+  const svgBlob = new Blob([new XMLSerializer().serializeToString(svg)], {
+    type: "image/svg+xml",
+  });
+  const svgBlobURL = URL.createObjectURL(svgBlob);
+  let svgImage: HTMLImageElement;
+  try {
+    svgImage = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image();
+      image.onabort = reject;
+      image.onerror = reject;
+      image.onload = () => {
+        resolve(image);
+      };
+      image.src = svgBlobURL;
+    });
+  } finally {
+    URL.revokeObjectURL(svgBlobURL);
+  }
+  renderContext.drawImage(svgImage, 0, 0);
+
+  const result = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, "image/png");
+  });
+  assert(result !== null);
+  return result;
+}

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -439,7 +439,7 @@ export function createStandardAvatarSVG({
   composedAvatar: SVGElement;
 }): SVGElement {
   const doc = new DOMParser().parseFromString(
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${STD_W} ${STD_H}" width="100%" height="100%"></svg>`,
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${STD_W} ${STD_H}"></svg>`,
     "image/svg+xml"
   );
   let redditLogo = redditLogoSVG();

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -238,7 +238,7 @@ export class SVGParseError extends Error {
   }
 }
 
-function _parseSVG({
+export function _parseSVG({
   svgSource,
   parseErrorMessage,
 }: {


### PR DESCRIPTION
In addition to SVG, Headgear now allows Avatars to be downloaded as PNG images. PNG images can also be copied. (SVG images can't be copied because Chrome doesn't permit `image/svg+xml` to be written to the clipboard.)

<img width="808" alt="image" src="https://user-images.githubusercontent.com/146503/197976408-3c817f4f-2c97-41e0-abe5-821c0783a34c.png">

<img width="810" alt="image" src="https://user-images.githubusercontent.com/146503/197976571-fd5519f7-2d5e-46ad-9f0d-d9e88021287d.png">



This resolves #15.