### PR TITLE
WIP: Firefox support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,25 +28,8 @@ jobs:
         run: |
           rm -rf dist
           npm run webpack-prod
-      - name: Create Chrome Extension zip archive
-        run: |
-          PACKAGE_JSON_VERSION="$(jq -r .version package.json)"
-          [[ v$PACKAGE_JSON_VERSION = ${{ github.ref_name }} ]] || {
-              echo "The package.json version does not match the tag. The tag must be the version with a 'v' prefix, e.g. 'v0.0.0'.";
-              exit 1;
-          }
-          npm run create-release-zip
-          mv dist.zip "headgear-${{ github.ref_name }}.zip"
-          mv dist-files.sha256 "headgear-files-${{ github.ref_name }}.sha256"
-          cat > RELEASE.txt << EOF
-          # Name: Headgear
-          # Version: $PACKAGE_JSON_VERSION
-          # Tag: ${{ github.ref_name }}
-          # Commit: ${{ github.sha }}
-          # Built-by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          EOF
-          sha256sum "headgear-${{ github.ref_name }}.zip" "headgear-files-${{ github.ref_name }}.sha256" | tee -a RELEASE.txt
-          sha256sum RELEASE.txt | tee RELEASE.txt.sha256
+      - name: Create Browser Extension zip archives
+        run: npm run assemble-release-files
         if: startsWith(github.ref, 'refs/tags/') || github.ref_name == 'ci'
       - name: Create GitHub Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@
 !.prettierrc.json
 /data
 /dist*
+/headgear-*
+/RELEASE*
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Firefox support. Headgear supports Firefox, from version 109, due to be
+  released on 2023-01-17. (This is the first version of Firefox with Manifest V3
+  support, which allows Headgear to work without significant changes.)
 - Text using custom fonts is now rendered with SVG paths instead of referencing
   web fonts from the SVG file. This removes all external dependencies, so SVG
   files are entirely stand-alone (no dependencies on Reddit keeping resources

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The following license applies to everything except for Reddit's SVG logos and
 Avatar assets.
 
-Copyright (c) 2022 Hal Blackburn
+Copyright (c) 2022–2023 Hal Blackburn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test-watch": "jest --watch",
     "eslint": "eslint src",
     "prettier-check": "prettier --check .",
-    "create-release-zip": "test ! -e dist.zip && test -d dist && cd dist && find . -type f | sort | xargs sha256sum | tee ../dist-files.sha256 && find . -type f -exec touch --no-dereference --date=1970-01-01T00:00:00Z {} + -print | sort | zip -9 -X -@ ../dist.zip"
+    "create-release-zip": "scripts/create-release-zip.sh",
+    "create-release-zips": "npm run create-release-zip chrome && npm run create-release-zip firefox",
+    "assemble-release-files": "scripts/assemble-release-files.sh"
   },
   "author": "Hal Blackburn",
   "license": "MIT",

--- a/scripts/assemble-release-files.sh
+++ b/scripts/assemble-release-files.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${script_dir:?}/.."
+
+ref_name="${GITHUB_REF_NAME:?}"     # e.g. v0.3.0
+server_url="${GITHUB_SERVER_URL:?}" # e.g. https://github.com
+repository="${GITHUB_REPOSITORY:?}" # e.g. h4l/headgear
+sha="${GITHUB_SHA:?}"               # e.g. d69a8048d3cc6aec0d9d4abc229996528fb6ad9e
+actions_run_id="${GITHUB_RUN_ID:?}" # e.g. 1658821493
+
+PACKAGE_JSON_VERSION="$(jq -r .version package.json)"
+[[ v$PACKAGE_JSON_VERSION = ${ref_name:?} ]] || {
+  echo "Error: The package.json version does not match the tag. The tag must" \
+    "be the version with a 'v' prefix, e.g. 'v0.0.0'." >&2;
+    exit 1;
+}
+npm run create-release-zips
+mv dist/dist-chrome.zip "headgear-chrome-${ref_name:?}.zip"
+mv dist/dist-chrome-files.sha256 "headgear-chrome-files-${ref_name:?}.sha256"
+mv dist/dist-firefox.zip "headgear-firefox-${ref_name:?}.zip"
+mv dist/dist-firefox-files.sha256 "headgear-firefox-files-${ref_name:?}.sha256"
+cat > RELEASE.txt << EOF
+# Name: Headgear
+# Version: $PACKAGE_JSON_VERSION
+# Tag: ${ref_name:?}
+# Commit: ${sha:?}
+# Built-by: ${server_url:?}/${repository:?}/actions/runs/${actions_run_id:?}
+EOF
+sha256sum "headgear-chrome-${ref_name:?}.zip" \
+          "headgear-chrome-files-${ref_name:?}.sha256" \
+          "headgear-firefox-${ref_name:?}.zip" \
+          "headgear-firefox-files-${ref_name:?}.sha256" \
+          | tee -a RELEASE.txt
+sha256sum RELEASE.txt | tee RELEASE.txt.sha256

--- a/scripts/create-release-zip.sh
+++ b/scripts/create-release-zip.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function fail() {
+  echo Error: ${1:?} >&2
+  exit 1
+}
+
+browser_target_err="The first argument must be 'chrome' or 'firefox'"
+browser_target="${1:?$browser_target_err}"
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+repo_root="$(dirname ${script_dir:?})"
+
+if [[ ! $browser_target =~ ^chrome|firefox$ ]]; then
+  fail "$browser_target_err, not: \"$browser_target\""
+fi
+
+cd "${repo_root:?}"
+
+dist_zip_file="${repo_root:?}/dist/dist-${browser_target:?}.zip"
+dist_checksums_file="${repo_root:?}/dist/dist-${browser_target:?}-files.sha256"
+dist_dir="${repo_root:?}/dist/${browser_target:?}"
+[[ ! -e ${dist_zip_file:?} ]] || fail "${dist_zip_file:?} already exists"
+[[ ! -e ${dist_checksums_file:?} ]] || fail "${dist_checksums_file:?} already exists"
+[[ -d "${dist_dir:?}" ]] || fail "${dist_dir:?} does not exist"
+
+cd "${dist_dir:?}" \
+  && find . -type f \
+  | sort \
+  | xargs sha256sum \
+  | tee "${dist_checksums_file:?}" \
+  && find . -type f -exec \
+  touch --no-dereference --date=1970-01-01T00:00:00Z {} + -print \
+  | sort \
+  | zip -9 -X -@ "${dist_zip_file:?}"

--- a/src/__tests__/__snapshots__/svg.ts.snap
+++ b/src/__tests__/__snapshots__/svg.ts.snap
@@ -167,6 +167,11 @@ exports[`Avatar SVG Headshot Comments Layout - createHeadshotCommentsAvatarSVG()
     <clippath
       id="avatar-upper"
     >
+      <rect>
+        <desc>
+          This is a workaround for a Firefox SVG rendering bug.
+        </desc>
+      </rect>
       <path
         d="M 190,488 325.52665,413 H 380 V 0 H 0 v 413 h 55 z"
       />

--- a/src/__tests__/compatibility.ts
+++ b/src/__tests__/compatibility.ts
@@ -1,0 +1,22 @@
+import {polyfillWebExtensionsAPI} from "../compatibility";
+
+describe("polyfillWebExtensionsAPI()", () => {
+  afterEach(() => {
+    delete (globalThis as { chrome?: unknown }).chrome;
+    delete (globalThis as { browser?: unknown }).browser;
+  });
+
+  test("does nothing if chrome is defined", () => {
+    const chrome = {};
+    (globalThis as { chrome?: unknown }).chrome = chrome;
+    polyfillWebExtensionsAPI();
+    expect(globalThis.chrome).toBe(chrome);
+  });
+
+  test("copies browser to chrome is chrome is not defined", () => {
+    const browser = {};
+    (globalThis as { browser?: unknown }).browser = browser;
+    polyfillWebExtensionsAPI();
+    expect(globalThis.chrome).toBe(browser);
+  });
+});

--- a/src/__tests__/compatibility.ts
+++ b/src/__tests__/compatibility.ts
@@ -1,6 +1,8 @@
+import { assert } from "../assert";
 import {
   polyfillWebExtensionsAPI,
   throwIfExecuteScriptResultFailed,
+  writeImageToClipboard,
 } from "../compatibility";
 
 describe("polyfillWebExtensionsAPI()", () => {
@@ -42,5 +44,79 @@ describe("throwIfExecuteScriptResultFailed()", () => {
     expect(() => {
       throwIfExecuteScriptResultFailed([errorResult]);
     }).toThrowError("chrome.scripting.executeScript() failed: Example error");
+  });
+});
+
+type Writable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+type Deletable<T> = Writable<Partial<T>>;
+
+describe("writeImageToClipboard()", () => {
+  class MockClipboardItem implements ClipboardItem {
+    get types(): readonly string[] {
+      throw new Error("Method not implemented.");
+    }
+    getType(): Promise<Blob> {
+      throw new Error("Method not implemented.");
+    }
+  }
+  beforeEach(() => {
+    assert(globalThis.ClipboardItem === undefined);
+    assert(globalThis.navigator !== undefined);
+    assert(globalThis.navigator.clipboard === undefined);
+    assert((globalThis as Record<string, unknown>).browser === undefined);
+  });
+
+  afterEach(() => {
+    delete (globalThis.navigator as Deletable<Navigator>).clipboard;
+    delete (globalThis as Deletable<typeof globalThis>).ClipboardItem;
+    delete (globalThis as Record<string, unknown>).browser;
+  });
+
+  test("browsers supporting ClipboardItem use navigator.clipboard.write", async () => {
+    // Chrome supports the standard ClipboardItem API to write to the clipboard
+    (globalThis as Writable<typeof globalThis>).ClipboardItem =
+      MockClipboardItem;
+    const mockClipboard: Partial<Clipboard> = {
+      write: jest.fn(),
+    };
+    (globalThis.navigator as Writable<Navigator>).clipboard =
+      mockClipboard as Clipboard;
+
+    const imageBlob = new Blob(["PNG"], { type: "image/png" });
+    await writeImageToClipboard(imageBlob);
+
+    expect(globalThis.navigator.clipboard.write).toBeCalledTimes(1);
+    expect(globalThis.navigator.clipboard.write).toBeCalledWith([
+      new ClipboardItem({ "image/png": imageBlob }),
+    ]);
+  });
+
+  test("Browsers without ClipboardItem use browser.clipboard.setImageData", async () => {
+    // Firefox doesn't support ClipboardItem, it provides a non-standard
+    // browser.clipboard.setImageData API.
+    const setImageData = jest.fn();
+    (globalThis as Record<string, unknown>).browser = {
+      clipboard: { setImageData },
+    };
+
+    const imageBlob = new Blob(["PNG"], { type: "image/png" });
+    assert(imageBlob.arrayBuffer === undefined);
+    const imageBlobAsArrayBuffer = { "mock-array-buffer-of": imageBlob };
+    imageBlob.arrayBuffer = jest.fn().mockResolvedValue(imageBlobAsArrayBuffer);
+
+    await writeImageToClipboard(imageBlob);
+
+    expect(setImageData).toBeCalledTimes(1);
+    expect(setImageData).toBeCalledWith(await imageBlob.arrayBuffer(), "png");
+  });
+
+  test("Browsers without either fail with an error", async () => {
+    const imageBlob = new Blob(["PNG"], { type: "image/png" });
+    await expect(writeImageToClipboard(imageBlob)).rejects.toThrow(
+      "Unable to copy image, no supported clipboard API available"
+    );
   });
 });

--- a/src/__tests__/compatibility.ts
+++ b/src/__tests__/compatibility.ts
@@ -1,4 +1,7 @@
-import {polyfillWebExtensionsAPI} from "../compatibility";
+import {
+  polyfillWebExtensionsAPI,
+  throwIfExecuteScriptResultFailed,
+} from "../compatibility";
 
 describe("polyfillWebExtensionsAPI()", () => {
   afterEach(() => {
@@ -18,5 +21,26 @@ describe("polyfillWebExtensionsAPI()", () => {
     (globalThis as { browser?: unknown }).browser = browser;
     polyfillWebExtensionsAPI();
     expect(globalThis.chrome).toBe(browser);
+  });
+});
+
+describe("throwIfExecuteScriptResultFailed()", () => {
+  test("does not throw for successful results", () => {
+    expect(() =>
+      throwIfExecuteScriptResultFailed([{ frameId: 123, result: undefined }])
+    ).not.toThrow();
+  });
+
+  test("throws if result has an error", () => {
+    const errorResult: chrome.scripting.InjectionResult<unknown> & {
+      error: unknown;
+    } = {
+      frameId: 123,
+      result: undefined,
+      error: "Example error",
+    };
+    expect(() => {
+      throwIfExecuteScriptResultFailed([errorResult]);
+    }).toThrowError("chrome.scripting.executeScript() failed: Example error");
   });
 });

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -200,6 +200,9 @@ describe("create & initialise RootState", () => {
   test("avatarDataState becomes AVATAR_LOADED if tab is reddit", async () => {
     const mockAvatarData = { avatar: true };
     jest
+      .mocked(chrome.scripting.executeScript)
+      .mockResolvedValue([{ frameId: 0, result: null }] as never);
+    jest
       .mocked(chrome.tabs.sendMessage)
       .mockResolvedValue([undefined, mockAvatarData]);
     const rootState = createRootState();
@@ -221,6 +224,9 @@ describe("create & initialise RootState", () => {
 
   test("avatarDataState becomes ERROR with type GET_AVATAR_FAILED if get-avatar message responds with an error", async () => {
     jest
+      .mocked(chrome.scripting.executeScript)
+      .mockResolvedValue([{ frameId: 0, result: null }] as never);
+    jest
       .mocked(chrome.tabs.sendMessage)
       .mockResolvedValue([
         { message: "An expected error occurred" },
@@ -241,6 +247,9 @@ describe("create & initialise RootState", () => {
   });
 
   test("avatarDataState becomes ERROR with type UNKNOWN if get-avatar handler throws", async () => {
+    jest
+      .mocked(chrome.scripting.executeScript)
+      .mockResolvedValue([{ frameId: 0, result: null }] as never);
     jest
       .mocked(chrome.tabs.sendMessage)
       .mockRejectedValue(new Error("An unexpected error occurred"));

--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -212,7 +212,7 @@ describe("create & initialise RootState", () => {
     assert(avatarDataState.value.type === DataStateType.LOADED);
     expect(chrome.scripting.executeScript).toBeCalledWith({
       target: { tabId: 123 },
-      files: ["reddit.js"],
+      files: ["/reddit.js"],
     });
     expect(chrome.tabs.sendMessage).toBeCalledWith(123, MSG_GET_AVATAR);
     expect(avatarDataState.value.tab).toBe(tab);

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,6 +2,7 @@ import debounce from "lodash.debounce";
 import isEqual from "lodash.isequal";
 
 import { assert } from "./assert";
+import { polyfillWebExtensionsAPI } from "./compatibility";
 import {
   ControlsStateObject,
   PORT_IMAGE_CONTROLS_CHANGED,
@@ -39,5 +40,6 @@ export function _persistImageControlsOnChange() {
 }
 
 export async function main() {
+  polyfillWebExtensionsAPI();
   _persistImageControlsOnChange();
 }

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -1,0 +1,20 @@
+// Non-chrome browsers provide the WebExtensions API on the global browser
+// property. I'd like to constrain the extension to use only Manifest V3 APIs,
+// and Chrome is currently the main supported platform. So I'm supporting
+// FireFox by typing the `browser` property as if it contained Chrome APIs.
+// Hopefully there's enough consistency with Manifest V3 APIs for this to be OK.
+type WebExtensionApi = {
+  browser?: typeof globalThis.chrome;
+};
+
+export function polyfillWebExtensionsAPI() {
+  if (!globalThis.chrome) {
+    const browser = (globalThis as WebExtensionApi).browser;
+    if (!browser) {
+      throw new Error(
+        "WebExtensions API not available on `chrome` or `browser` global"
+      );
+    }
+    globalThis.chrome = browser;
+  }
+}

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -18,3 +18,26 @@ export function polyfillWebExtensionsAPI() {
     globalThis.chrome = browser;
   }
 }
+
+interface FirefoxInjectionResult<T>
+  extends chrome.scripting.InjectionResult<T> {
+  error?: unknown;
+}
+
+/**
+ * Detect and handle errors in an chrome.scripting.executeScript() result array.
+ *
+ * Firefox doesn't reject the executeScript() promise, rather each element in
+ * the returned array can have an error property.
+ */
+export function throwIfExecuteScriptResultFailed(
+  executeScriptResult: chrome.scripting.InjectionResult<unknown>[]
+): void {
+  for (const result of executeScriptResult as FirefoxInjectionResult<unknown>[]) {
+    if (result.error) {
+      throw new Error(
+        `chrome.scripting.executeScript() failed: ${result.error}`
+      );
+    }
+  }
+}

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -7,7 +7,7 @@
     <title>Popup</title>
   </head>
 
-  <body>
-    <iframe src="./text-to-path-service.html"></iframe>
+  <body class="overflow-hidden">
+    <iframe class="hidden" src="./text-to-path-service.html"></iframe>
   </body>
 </html>

--- a/src/img/avatar-svg/headshot-comments-template.svg
+++ b/src/img/avatar-svg/headshot-comments-template.svg
@@ -15,6 +15,16 @@
         </linearGradient>
         <path id="hex-frame" stroke="url(#hex-frame-stroke)" stroke-linejoin="round" stroke-width="16" d="m 177.75041,189.74577 c 7.64778,-4.12577 17.10688,-4.12577 24.75465,0 l 118.43998,65.2074 c 7.54715,4.2264 12.07544,11.77355 12.07544,19.72322 v 130.21353 c 0,7.94966 -4.52829,15.49681 -12.07544,19.62259 l -118.43998,65.10677 c -7.64777,4.2264 -17.10687,4.2264 -24.75465,0 L 59.310436,424.41188 A 22.641456,22.641456 0 0 1 47.235,404.78929 V 274.57576 c 0,-7.94967 4.42766,-15.39619 12.075436,-19.72323 z"/>
         <clipPath id="avatar-upper">
+            <rect>
+                <!-- This rect only exists to work around an apparent bug in
+                Firefox's handling of this clipPath in conjuction with the
+                avatar SVG. Without another graphical element in this clipPath,
+                Firefox renders the clipPath as if it starts at ~120 units from
+                the top, instead of at the top, which results in the top of the
+                avatar being clipped off. With this no-op rect here, FF renders
+                the clip in the same way as Chrome, Inkscape, etc. -->
+                <desc>This is a workaround for a Firefox SVG rendering bug.</desc>
+            </rect>
             <path d="M 190,488 325.52665,413 H 380 V 0 H 0 v 413 h 55 z" />
         </clipPath>
         <clipPath id="hex-frame-foreground-clip">

--- a/src/popup-entry.tsx
+++ b/src/popup-entry.tsx
@@ -1,6 +1,8 @@
 import { render } from "preact";
 
+import { polyfillWebExtensionsAPI } from "./compatibility";
 import "./css.css";
 import { App } from "./popup";
 
+polyfillWebExtensionsAPI();
 render(<App />, document.body);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1381,7 +1381,7 @@ export async function _getUserCurrentAvatar(
   assert(typeof tabId === "number");
   await chrome.scripting.executeScript({
     target: { tabId },
-    files: ["reddit.js"],
+    files: ["/reddit.js"],
   });
   const [err, avatar] = (await chrome.tabs.sendMessage(
     tabId,

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -13,7 +13,10 @@ import {
 
 import { assert, assertNever } from "./assert";
 import { ResolvedAvatar } from "./avatars";
-import { throwIfExecuteScriptResultFailed } from "./compatibility";
+import {
+  throwIfExecuteScriptResultFailed,
+  writeImageToClipboard,
+} from "./compatibility";
 import { computedAsync, serialiseExecutions } from "./computed-async";
 import {
   ControlsStateObject,
@@ -774,8 +777,7 @@ export function CopyImageButton(): JSX.Element {
     }
     copyState.value = CopyState.COPYING;
     const imageBlob = outputImageState.value.blob;
-    navigator.clipboard
-      .write([new ClipboardItem({ [imageBlob.type]: imageBlob })])
+    writeImageToClipboard(imageBlob)
       .then(() => {
         copyState.value = CopyState.COPIED;
       })

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -13,6 +13,7 @@ import {
 
 import { assert, assertNever } from "./assert";
 import { ResolvedAvatar } from "./avatars";
+import { throwIfExecuteScriptResultFailed } from "./compatibility";
 import { computedAsync, serialiseExecutions } from "./computed-async";
 import {
   ControlsStateObject,
@@ -1379,10 +1380,11 @@ export async function _getUserCurrentAvatar(
 ): Promise<ResolvedAvatar | null> {
   const tabId = tab.id;
   assert(typeof tabId === "number");
-  await chrome.scripting.executeScript({
+  const result = await chrome.scripting.executeScript({
     target: { tabId },
     files: ["/reddit.js"],
   });
+  throwIfExecuteScriptResultFailed(result);
   const [err, avatar] = (await chrome.tabs.sendMessage(
     tabId,
     MSG_GET_AVATAR

--- a/src/reddit.ts
+++ b/src/reddit.ts
@@ -3,6 +3,8 @@
  * handling requests for avatar data from the main extension (running in a
  * separate context).
  */
+import { polyfillWebExtensionsAPI } from "./compatibility";
 import { registerMessageHandler } from "./reddit-interaction";
 
+polyfillWebExtensionsAPI();
 registerMessageHandler();

--- a/src/webpack-defines.d.ts
+++ b/src/webpack-defines.d.ts
@@ -1,0 +1,6 @@
+// Defined in webpack config via DefinePlugin
+interface HeadgearGlobalObject {
+  FEATURE_CANVAS_SVG_ABSOLUTE_DIMENSIONS: boolean;
+}
+
+declare const HeadgearGlobal: HeadgearGlobalObject;

--- a/webpack-common.ts
+++ b/webpack-common.ts
@@ -52,8 +52,10 @@ class GenerateManifestPlugin {
 
 export function createConfig(options: {
   mode: "development" | "production";
+  browser: "chrome" | "firefox";
 }): Configuration {
   const config: Configuration = {
+    name: options.browser,
     entry: {
       background: "./src/background-entry.ts",
       popup: "./src/popup-entry.tsx",
@@ -92,7 +94,7 @@ export function createConfig(options: {
     },
     output: {
       filename: "[name].js",
-      path: path.resolve(__dirname, "dist"),
+      path: path.resolve(__dirname, "dist", options.browser),
     },
 
     plugins: [

--- a/webpack-common.ts
+++ b/webpack-common.ts
@@ -72,6 +72,11 @@ class GenerateManifestPlugin {
       // https://blog.mozilla.org/addons/2022/10/31/begin-your-mv3-migration-by-implementing-new-features-today/
       manifest.background.scripts = [manifest.background.service_worker];
       delete manifest.background.service_worker;
+
+      // Firefox needs the clipboardWrite permission to write images to the
+      // clipboard.
+      // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
+      manifest.permissions.push("clipboardWrite");
     }
 
     return new sources.RawSource(JSON.stringify(manifest, undefined, 2));

--- a/webpack-common.ts
+++ b/webpack-common.ts
@@ -137,6 +137,7 @@ export function createConfig(options: {
           { from: "./src/html/*.html", to: "html/[name].html" },
           { from: "./src/img/*", to: "img/[name][ext]" },
           { from: "./src/font/*", to: "font/[name][ext]" },
+          { from: "./LICENSE" },
         ],
       }),
       // This is a conditional import that we don't trigger, and if it's

--- a/webpack-common.ts
+++ b/webpack-common.ts
@@ -8,6 +8,9 @@ import {
   IgnorePlugin,
   sources,
 } from "webpack";
+import merge from "webpack-merge";
+
+import { assert } from "./src/assert";
 
 /** Generate manifest.json */
 class GenerateManifestPlugin {
@@ -47,66 +50,90 @@ class GenerateManifestPlugin {
   }
 }
 
-const config: Configuration = {
-  entry: {
-    background: "./src/background-entry.ts",
-    popup: "./src/popup-entry.tsx",
-    reddit: "./src/reddit.ts",
-    "text-to-path-service": "./src/text-to-path/service-entry.ts",
-  },
-  devtool: "source-map",
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: "ts-loader",
-        exclude: [/node_modules/, /\.test\.ts$/],
-      },
-      // Include source maps from the various Preact dependencies. Preact ships
-      // minified code, so if we don't load their source maps we can't really
-      // debug their modules.
-      {
-        use: "source-map-loader",
-        enforce: "pre",
-        test: /\.js$/,
-        include: [
-          // path.resolve(__dirname, "node_modules/@preact/signals-core")
-          /\/node_modules\/.*(?<=\/)@?preact\b/,
-        ],
-      },
-      {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader", "postcss-loader"],
-      },
-      {
-        test: /\.svg$/,
-        type: "asset/source",
-      },
-    ],
-  },
-  resolve: {
-    extensions: [".tsx", ".ts", ".js"],
-  },
-  output: {
-    filename: "[name].js",
-    path: path.resolve(__dirname, "dist"),
-  },
-
-  plugins: [
-    new GenerateManifestPlugin(),
-    new CopyPlugin({
-      patterns: [
-        { from: "./src/html/*.html", to: "html/[name].html" },
-        { from: "./src/img/*", to: "img/[name][ext]" },
-        { from: "./src/font/*", to: "font/[name][ext]" },
+export function createConfig(options: {
+  mode: "development" | "production";
+}): Configuration {
+  const config: Configuration = {
+    entry: {
+      background: "./src/background-entry.ts",
+      popup: "./src/popup-entry.tsx",
+      reddit: "./src/reddit.ts",
+      "text-to-path-service": "./src/text-to-path/service-entry.ts",
+    },
+    devtool: "source-map",
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: "ts-loader",
+          exclude: [/node_modules/, /\.test\.ts$/],
+        },
+        // Include source maps from the various Preact dependencies. Preact
+        // ships minified code, so if we don't load their source maps we can't
+        // really debug their modules.
+        {
+          use: "source-map-loader",
+          enforce: "pre",
+          test: /\.js$/,
+          include: [/\/node_modules\/.*(?<=\/)@?preact\b/],
+        },
+        {
+          test: /\.css$/,
+          use: ["style-loader", "css-loader", "postcss-loader"],
+        },
+        {
+          test: /\.svg$/,
+          type: "asset/source",
+        },
       ],
-    }),
-    // This is a conditional import that we don't trigger, and if it's included
-    // it requires polyfills for node modules like fs.
-    new IgnorePlugin({
-      contextRegExp: /css\/lib\/stringify/,
-      resourceRegExp: /source-map-support/,
-    }),
-  ],
-};
-export default config;
+    },
+    resolve: {
+      extensions: [".tsx", ".ts", ".js"],
+    },
+    output: {
+      filename: "[name].js",
+      path: path.resolve(__dirname, "dist"),
+    },
+
+    plugins: [
+      new GenerateManifestPlugin(),
+      new CopyPlugin({
+        patterns: [
+          { from: "./src/html/*.html", to: "html/[name].html" },
+          { from: "./src/img/*", to: "img/[name][ext]" },
+          { from: "./src/font/*", to: "font/[name][ext]" },
+        ],
+      }),
+      // This is a conditional import that we don't trigger, and if it's
+      // included it requires polyfills for node modules like fs.
+      new IgnorePlugin({
+        contextRegExp: /css\/lib\/stringify/,
+        resourceRegExp: /source-map-support/,
+      }),
+    ],
+  };
+
+  let overrides: Configuration;
+  if (options.mode === "development") {
+    overrides = {
+      mode: "development",
+    };
+  } else {
+    assert(options.mode === "production");
+    overrides = {
+      mode: "production",
+      optimization: {
+        // The Chrome Web Store policies prohibit code obfuscation. They do
+        // permit regular minification, so we could leave minimize on. But
+        // turning it off only costs ~10KB on the final zip package, and makes
+        // it easier to verify the code's behaviour. So I'm going to disable
+        // minification for production builds.
+        // https://developer.chrome.com/docs/webstore/program_policies/#code-readability
+        // https://blog.chromium.org/2018/10/trustworthy-chrome-extensions-by-default.html
+        minimize: false,
+      },
+    };
+  }
+
+  return merge(config, overrides);
+}

--- a/webpack-common.ts
+++ b/webpack-common.ts
@@ -5,6 +5,7 @@ import {
   Compilation,
   Compiler,
   Configuration,
+  DefinePlugin,
   IgnorePlugin,
   sources,
 } from "webpack";
@@ -138,6 +139,11 @@ export function createConfig(options: {
       new IgnorePlugin({
         contextRegExp: /css\/lib\/stringify/,
         resourceRegExp: /source-map-support/,
+      }),
+      new DefinePlugin({
+        HeadgearGlobal: {
+          FEATURE_CANVAS_SVG_ABSOLUTE_DIMENSIONS: options.browser === "firefox",
+        },
       }),
     ],
   };

--- a/webpack-config-dev.ts
+++ b/webpack-config-dev.ts
@@ -1,3 +1,6 @@
 import { createConfig } from "./webpack-common";
 
-export default createConfig({ mode: "development" });
+export default [
+  createConfig({ mode: "development", browser: "chrome" }),
+  createConfig({ mode: "development", browser: "firefox" }),
+];

--- a/webpack-config-dev.ts
+++ b/webpack-config-dev.ts
@@ -1,7 +1,3 @@
-import { merge } from "webpack-merge";
+import { createConfig } from "./webpack-common";
 
-import commonConfig from "./webpack-common";
-
-export default merge(commonConfig, {
-  mode: "development",
-});
+export default createConfig({ mode: "development" });

--- a/webpack-config-prod.ts
+++ b/webpack-config-prod.ts
@@ -1,3 +1,6 @@
 import { createConfig } from "./webpack-common";
 
-export default createConfig({ mode: "production" });
+export default [
+  createConfig({ mode: "production", browser: "chrome" }),
+  createConfig({ mode: "production", browser: "firefox" }),
+];

--- a/webpack-config-prod.ts
+++ b/webpack-config-prod.ts
@@ -1,17 +1,3 @@
-import { merge } from "webpack-merge";
+import { createConfig } from "./webpack-common";
 
-import commonConfig from "./webpack-common";
-
-export default merge(commonConfig, {
-  mode: "production",
-  optimization: {
-    // The Chrome Web Store policies prohibit code obfuscation. They do permit
-    // regular minification, so we could leave minimize on. But turning it off
-    // only costs ~10KB on the final zip package, and makes it easier to verify
-    // the code's behaviour. So I'm going to disable minification for production
-    // builds.
-    // https://developer.chrome.com/docs/webstore/program_policies/#code-readability
-    // https://blog.chromium.org/2018/10/trustworthy-chrome-extensions-by-default.html
-    minimize: false,
-  },
-});
+export default createConfig({ mode: "production" });


### PR DESCRIPTION
This PR implements support for Firefox (#18).

## Status

The extension is loadable and basic functionality works in Firefox, but there are some issues to resolve.

## TODO

- [x] Fix popup viewport overflowing to the right and being horizontally-scrollable in Firefox
- [x] Web fonts in the NFT card SVG image are not rendered when drawing on a canvas. Need to embed the fonts, or convert them to a path (#1 )
  - Resolved via PR #20 — text with custom fonts is now rendered via SVG paths
- [x] Fix Firefox rendering nothing when drawing SVG on a canvas
- [x] Fix image copying not working in Firefox
- [x] Fix Firefox SVG clipPath bug that was clipping off the top of the comment hex avatar
- [x] QA for other issues
- [x] Update CI release build to handle the separate Firefox and Chrome package builds
