### PR TITLE
Fix text shadow clipping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ insert_final_newline = true
 indent_style = space
 trim_trailing_whitespace = true
 indent_size = 2
+
+[*.svg]
+indent_size = 4

--- a/src/__tests__/__snapshots__/svg.ts.snap
+++ b/src/__tests__/__snapshots__/svg.ts.snap
@@ -412,9 +412,12 @@ exports[`Avatar SVG NFT Card Layout - createNFTCardAvatarSVG() renders free NFT 
   >
     <defs>
       <filter
+        filterUnits="userSpaceOnUse"
+        height="100%"
         id="shadow"
-        width="200%"
-        x="-50%"
+        width="100%"
+        x="0"
+        y="0"
       >
         <fegaussianblur
           in="SourceAlpha"
@@ -453,7 +456,12 @@ exports[`Avatar SVG NFT Card Layout - createNFTCardAvatarSVG() renders free NFT 
         />
       </lineargradient>
       <mask
+        height="100%"
         id="mask"
+        maskUnits="userSpaceOnUse"
+        width="100%"
+        x="0"
+        y="0"
       >
         <rect
           fill="url(#gradient)"
@@ -664,9 +672,12 @@ exports[`Avatar SVG NFT Card Layout - createNFTCardAvatarSVG() renders regular N
   >
     <defs>
       <filter
+        filterUnits="userSpaceOnUse"
+        height="100%"
         id="shadow"
-        width="200%"
-        x="-50%"
+        width="100%"
+        x="0"
+        y="0"
       >
         <fegaussianblur
           in="SourceAlpha"
@@ -705,7 +716,12 @@ exports[`Avatar SVG NFT Card Layout - createNFTCardAvatarSVG() renders regular N
         />
       </lineargradient>
       <mask
+        height="100%"
         id="mask"
+        maskUnits="userSpaceOnUse"
+        width="100%"
+        x="0"
+        y="0"
       >
         <rect
           fill="url(#gradient)"

--- a/src/img/avatar-svg/nft-name-with-count.svg
+++ b/src/img/avatar-svg/nft-name-with-count.svg
@@ -15,8 +15,8 @@
 }
     </style>
     <defs>
-        <!-- Extra width to stop the shadow clipping on narrow text. -->
-        <filter id="shadow" x="-50%" width="200%">
+        <!-- The filter and mask are sized to fill the containing svg's viewBox. -->
+        <filter id="shadow" filterUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
             <!-- Some SVG renderers don't support feDropShadow, but it's
                  equivalent to the following, which is better supported. -->
             <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
@@ -32,7 +32,7 @@
             <stop offset="97%" stop-color="white" />
             <stop offset="99%" stop-color="black" />
         </linearGradient>
-        <mask id="mask">
+        <mask id="mask" maskUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
             <rect width="100%" height="100%" fill="url(#gradient)" />
         </mask>
     </defs>

--- a/src/img/avatar-svg/nft-name.svg
+++ b/src/img/avatar-svg/nft-name.svg
@@ -10,7 +10,7 @@
     </style>
     <defs>
         <!-- Extra width to stop the shadow clipping on narrow text. -->
-        <filter id="shadow" x="-50%" width="200%">
+        <filter id="shadow" filterUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
             <!-- Some SVG renderers don't support feDropShadow, but it's
                  equivalent to the following, which is better supported. -->
             <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
@@ -26,7 +26,7 @@
             <stop offset="97%" stop-color="white" />
             <stop offset="99%" stop-color="black" />
         </linearGradient>
-        <mask id="mask">
+        <mask id="mask" maskUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
             <rect width="100%" height="100%" fill="url(#gradient)" />
         </mask>
     </defs>


### PR DESCRIPTION
Shadows are no longer clipped on NFT Card Avatar name text. This fixes #23.

The change in 4.0.2 to render text as SVG paths introduced a subtle defect in the text shadow rendering — shadows were clipped with a hard edge before they'd fully faded out above and below the text.

---
## Before
![before](https://user-images.githubusercontent.com/146503/214386136-6ef2be3d-eec3-4c40-a287-0037c9171186.png)

## After
![after](https://user-images.githubusercontent.com/146503/214386160-1b9f5b77-e688-458e-875a-3dbe7fea42ac.png)

