### PR TITLE
chore: update Avatar Data GQL query ID

### DIFF
--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -203,7 +203,7 @@ async function _graphqlJsonApiRequest<T>({
  *   change.
  */
 // AvatarBuilderCatalogWithStorefront GQL query
-export const _GQL_QUERY_ID_AVATAR_DATA = "18f86c0ecf82";
+export const _GQL_QUERY_ID_AVATAR_DATA = "e60eb3c641f1";
 // GetNftDetails GQL query
 export const _GQL_QUERY_ID_NFT_INFO = "e9865cc4d93d";
 


### PR DESCRIPTION
Not sure how frequently this changes, but it's nice of Reddit to keep the old one working. 🥰 I guess it was last changed when they introduced the feature allowing specific backgrounds to be chosen, because the current response seems to explicitly specify the background used on a user avatar. So we can probably get rid of the previous hack that parsed / base64-decoded the pre-composed avatar image URL to extract the NFT ID. For now the old method is still compatible though.