### PR TITLE
fix(analytics): ensure analytics is enabled for opted-in users

### DIFF
--- a/__mocks__/posthog-js.ts
+++ b/__mocks__/posthog-js.ts
@@ -1,26 +1,11 @@
-import { PostHog as _PostHog } from "posthog-js";
+import { PostHog } from "posthog-js";
 
-class PostHog
-  implements
-    Pick<
-      _PostHog,
-      "capture" | "init" | "opt_in_capturing" | "opt_out_capturing" | "register"
-    >
-{
-  capture: _PostHog["capture"] = jest.fn();
-  init: _PostHog["init"] = jest.fn();
-  opt_in_capturing: _PostHog["opt_in_capturing"] = jest.fn();
-  opt_out_capturing: _PostHog["opt_out_capturing"] = jest.fn();
-  register: _PostHog["register"] = jest.fn();
-  constructor() {
-    jest.mocked(this.init).mockReturnValue(this as unknown as _PostHog);
-  }
-}
+import { MockPostHog } from "../src/__tests__/posthog-js.mock";
 
 const mod: typeof import("posthog-js") =
   jest.createMockFromModule("posthog-js");
 
-mod.PostHog = PostHog as typeof _PostHog;
-mod.default = new PostHog() as _PostHog;
+mod.PostHog = MockPostHog as unknown as typeof PostHog;
+mod.default = new MockPostHog() as unknown as PostHog;
 mod.posthog = mod.default;
 module.exports = mod;

--- a/src/__tests__/posthog-js.mock.ts
+++ b/src/__tests__/posthog-js.mock.ts
@@ -1,0 +1,76 @@
+import { PostHog } from "posthog-js";
+
+import { assert } from "../assert";
+import { AnalyticsPreference } from "../popup-state-persistence";
+
+export type OptInOut =
+  | AnalyticsPreference.OPTED_IN
+  | AnalyticsPreference.OPTED_OUT;
+type ResetState = { capturingPreference?: OptInOut };
+
+export class MockPostHog
+  implements
+    Pick<
+      PostHog,
+      | "capture"
+      | "init"
+      | "opt_in_capturing"
+      | "opt_out_capturing"
+      | "has_opted_in_capturing"
+      | "has_opted_out_capturing"
+      | "register"
+    >
+{
+  capture: PostHog["capture"] = jest.fn();
+  init: PostHog["init"] = jest.fn();
+  register: PostHog["register"] = jest.fn();
+
+  #capturingPreference: OptInOut = AnalyticsPreference.OPTED_IN;
+  constructor() {
+    this.resetState();
+    jest.mocked(this.init).mockReturnValue(this as unknown as PostHog);
+    const spyable = this as unknown as Record<keyof PostHog, () => undefined>;
+    jest.spyOn(spyable, "has_opted_out_capturing");
+    jest.spyOn(spyable, "opt_in_capturing");
+    jest.spyOn(spyable, "opt_out_capturing");
+  }
+
+  /**
+   * Reset the instance state of this [Mock]PostHog object. Does not reset/clear
+   * the mock functions themselves.
+   */
+  resetState(state?: ResetState) {
+    this.#capturingPreference =
+      state?.capturingPreference ?? AnalyticsPreference.OPTED_IN;
+    assert(
+      this.#capturingPreference === AnalyticsPreference.OPTED_IN ||
+        this.#capturingPreference === AnalyticsPreference.OPTED_OUT
+    );
+  }
+
+  has_opted_out_capturing(): boolean {
+    return this.#capturingPreference === AnalyticsPreference.OPTED_OUT;
+  }
+  has_opted_in_capturing(): boolean {
+    return this.#capturingPreference === AnalyticsPreference.OPTED_IN;
+  }
+  opt_in_capturing(): void {
+    this.#capturingPreference = AnalyticsPreference.OPTED_IN;
+  }
+  opt_out_capturing(): void {
+    this.#capturingPreference = AnalyticsPreference.OPTED_OUT;
+  }
+}
+
+export function mockedPostHog(postHog: MockPostHog | PostHog): MockPostHog {
+  if (!(postHog instanceof MockPostHog))
+    throw new TypeError("object is not a MockPostHog instance");
+  return postHog;
+}
+
+export function resetMockPostHog(
+  postHog: MockPostHog | PostHog,
+  state?: ResetState
+) {
+  mockedPostHog(postHog).resetState(state);
+}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1750,7 +1750,8 @@ export function _initAnalyticsState({
           headgearVersion: HeadgearGlobal.HEADGEAR_BUILD.version,
           headgearBrowser: HeadgearGlobal.HEADGEAR_BUILD.browserTarget,
         });
-      } else {
+      }
+      if (!postHog.has_opted_in_capturing()) {
         postHog.opt_in_capturing();
       }
       analyticsStateSignal.value = postHog;


### PR DESCRIPTION
Previously, analytics events were not actually active if a user opted-in after having started from an opted-out state. This was because the logic assumed that calling `init()` on a PostHog instance would also enable/opt-in analytics, but PostHog requires an explicit opt-in after having been opted-out.

We now check the PostHog opt-in/out state when opting in, and opt in explicitly if required.

This fixes https://github.com/h4l/headgear/issues/29