### PR TITLE
fix: 0-pad numbers in download filenames

### DIFF
--- a/src/__tests__/popup.tsx
+++ b/src/__tests__/popup.tsx
@@ -700,6 +700,21 @@ describe("<DownloadImageButton>", () => {
 });
 
 describe("Avatar Image Download Filename", () => {
+  test.each`
+    inputTime                     | formattedTime
+    ${"2023-10-23T19:30:34.819Z"} | ${"2023-10-23 at 19.30.34"}
+    ${"2023-01-02T03:04:05.819Z"} | ${"2023-01-02 at 03.04.05"}
+  `(
+    "_formatTimeForFilename() formats $inputTime as $formattedTime",
+    async (options: { inputTime: string; formattedTime: string }) => {
+      const timestamp = Date.parse(options.inputTime);
+
+      expect(_internals._formatTimeForFilename(timestamp)).toEqual(
+        options.formattedTime
+      );
+    }
+  );
+
   test("Download Filename has expected format", async () => {
     const controlsState: ControlsStateObject = {
       ...DEFAULT_CONTROLS_STATE,
@@ -709,12 +724,12 @@ describe("Avatar Image Download Filename", () => {
       styles: [],
       nftInfo: undefined,
     };
-    const timestamp = Date.parse("2023-01-23T19:30:34.819Z");
+    const timestamp = Date.parse("2023-01-23T09:30:34.819Z");
 
     expect(
       _internals._getAvatarFilename({ controlsState, avatar, timestamp })
     ).toMatchInlineSnapshot(
-      `"Reddit Avatar Standard 2023-1-23 at 19.30.34.png"`
+      `"Reddit Avatar Standard 2023-01-23 at 09.30.34.png"`
     );
 
     controlsState.outputImageFormat = OutputImageFormat.SVG;
@@ -724,7 +739,7 @@ describe("Avatar Image Download Filename", () => {
     expect(
       _internals._getAvatarFilename({ controlsState, avatar, timestamp })
     ).toMatchInlineSnapshot(
-      `"Super Rare #1 NFT Card 2023-1-23 at 19.30.34.svg"`
+      `"Super Rare #1 NFT Card 2023-01-23 at 09.30.34.svg"`
     );
   });
 });

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -637,12 +637,14 @@ const IMAGE_STYLE_NAMES: Record<ImageStyleType, string> = {
 
 function _formatTimeForFilename(timestamp: number): string {
   const d = new Date(timestamp);
+  const pad = (s: number | string) => `${s}`.padStart(2, "0");
   // e.g. "2023-1-23 at 18.23.8" — the format MacOS uses for screenshots. Sorts
   // lexicographically with time and does not contain / or : (which are commonly
   // used in paths/URLs).
-  return `${d.getFullYear()}-${
-    d.getMonth() + 1
-  }-${d.getDate()} at ${d.getHours()}.${d.getMinutes()}.${d.getSeconds()}`;
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `at ${pad(d.getHours())}.${pad(d.getMinutes())}.${pad(d.getSeconds())}`
+  );
 }
 
 function _getAvatarFilename({
@@ -1771,5 +1773,6 @@ export function _initAnalyticsState({
 }
 
 export const _internals = {
+  _formatTimeForFilename,
   _getAvatarFilename,
 };


### PR DESCRIPTION
The filenames are supposed to sort lexicographically with date/time, but I forgot to 0-pad the numbers.