### PR TITLE
build(ci): update GitHub Release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm run assemble-release-files
         if: startsWith(github.ref, 'refs/tags/') || github.ref_name == 'ci'
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
We now use softprops/action-gh-release v0.1.15 (pinned via commit hash). This version updates the version of node it uses, which stops warnings about obsolete node versions during CI runs.