### PR TITLE
feat: support m (million) suffix NFT series size

### DIFF
--- a/src/__tests__/svg.ts
+++ b/src/__tests__/svg.ts
@@ -507,12 +507,22 @@ describe("Avatar SVG", () => {
     );
 
     test.each`
-      seriesSize | renderedSeriesSize
-      ${null}    | ${null}
-      ${600}     | ${"600"}
-      ${1000}    | ${"1k"}
-      ${1200}    | ${"1.2k"}
-      ${1289}    | ${"1.3k"}
+      seriesSize   | renderedSeriesSize
+      ${null}      | ${undefined}
+      ${600}       | ${"600"}
+      ${999}       | ${"999"}
+      ${1000}      | ${"1k"}
+      ${1200}      | ${"1.2k"}
+      ${1289}      | ${"1.3k"}
+      ${10000}     | ${"10k"}
+      ${10200}     | ${"10k"}
+      ${10600}     | ${"11k"}
+      ${2e6}       | ${"2m"}
+      ${2.2e6}     | ${"2.2m"}
+      ${1e6 - 1}   | ${"1m"}
+      ${1e6 - 501} | ${"999k"}
+      ${10.2e6}    | ${"10m"}
+      ${10.6e6}    | ${"11m"}
     `(
       "nftNameSVG() renders seriesSize $seriesSize",
       async ({
@@ -520,7 +530,7 @@ describe("Avatar SVG", () => {
         renderedSeriesSize,
       }: {
         seriesSize: null | number;
-        renderedSeriesSize: null | string;
+        renderedSeriesSize: undefined | string;
       }) => {
         const _avatar = avatar();
         assert(_avatar.nftInfo);
@@ -530,15 +540,9 @@ describe("Avatar SVG", () => {
           variant: NFTCardVariant.SHOP_INVENTORY,
         });
 
-        if (renderedSeriesSize === null) {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(nftName.querySelector("#series-size")).toBeFalsy();
-        } else {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(nftName.querySelector("#series-size")?.textContent).toEqual(
-            renderedSeriesSize
-          );
-        }
+        expect(nftName.querySelector("#series-size")?.textContent).toEqual(
+          renderedSeriesSize
+        );
       }
     );
   });

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -559,6 +559,18 @@ function getAbsolutePosition(el: Element, axis: "x" | "y"): number {
   return base + size * fraction;
 }
 
+function formatSeriesSize(seriesSize: number) {
+  return seriesSize < 1000
+    ? seriesSize.toFixed(0)
+    : Math.round(seriesSize / 1000) < 10
+    ? `${(seriesSize / 1000).toFixed(1).replace(/\.0$/, "")}k`
+    : Math.round(seriesSize / 1000) < 1000
+    ? `${(seriesSize / 1000).toFixed(0).replace(/\.0$/, "")}k`
+    : Math.round(seriesSize / 1e6) < 10
+    ? `${(seriesSize / 1e6).toFixed(1).replace(/\.0$/, "")}m`
+    : `${(seriesSize / 1e6).toFixed(0).replace(/\.0$/, "")}m`;
+}
+
 export async function _nftNameSVG(options: {
   nftInfo: NFTInfo;
   variant: NFTCardVariant;
@@ -576,10 +588,7 @@ export async function _nftNameSVG(options: {
     seriesSizeNumerator = svg.querySelector("#series-size-numerator");
     seriesSize = svg.querySelector("#series-size");
     assert(seriesSize);
-    seriesSize.textContent =
-      nftInfo.seriesSize < 1000
-        ? nftInfo.seriesSize.toFixed(0)
-        : `${(nftInfo.seriesSize / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+    seriesSize.textContent = formatSeriesSize(nftInfo.seriesSize);
   }
   const name = svg.querySelector("#nft-name");
   assert(name);
@@ -794,6 +803,6 @@ export function createHeadshotCommentsAvatarSVG({
 }
 
 export const _internals = {
-  parseViewBox,
   getAbsolutePosition,
+  parseViewBox,
 };


### PR DESCRIPTION
The series size graphic on the NFT card layout now supports series sizes in the millions. The NFL collection [seems to use 2m series size](https://www.reddit.com/r/avatartrading/comments/10srykc/new_nfl_collection/).